### PR TITLE
Add async question preloading

### DIFF
--- a/main/templates/practice_questions.html
+++ b/main/templates/practice_questions.html
@@ -174,7 +174,7 @@
     {% include 'navbar.html' %}
     <div class="container mt-5">
         <h1 class="text-center mb-4">Practice Questions</h1>
-        <div id="question-container">
+        <div id="question-container" data-session-code="{{ session_code }}" data-subtopic="{{ subtopic }}">
             {% for question in questions %}
             <div class="question question-container" data-question-id="{{ question.question_id }}" data-answer="{{ question.answer }}" style="display: none;">
                 <img src="data:image/png;base64,{{ question.image_base64 }}" alt="Question Image" class="mb-4">
@@ -237,30 +237,57 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <script>
         let currentIndex = 0;
-        const questions = $('.question');
+        let loading = false;
+        let sessionCode = $('#question-container').data('session-code');
+        let subtopic = $('#question-container').data('subtopic');
+        let questions = $('.question');
         questions.hide().eq(currentIndex).show();
 
-        $('.answer-btn').click(function () {
+        function collectIds() {
+            return $('.question').map(function () { return $(this).data('question-id'); }).get();
+        }
+
+        function addQuestionsToDOM(newQs) {
+            newQs.forEach(q => {
+                const html = `\n                <div class="question question-container" data-question-id="${q.question_id}" data-answer="${q.answer}" style="display:none;">\n                    <img src="data:image/png;base64,${q.image_base64}" alt="Question Image" class="mb-4">\n                    <div class="button-group">\n                        <button class="side-button star" title="Star"><i class="bi bi-star-fill"></i></button>\n                        <button class="side-button bookmark" title="Bookmark"><i class="bi bi-bookmark-fill"></i></button>\n                        <button class="side-button reveal" title="Reveal Answer"><i class="bi bi-eye-fill"></i></button>\n                    </div>\n                    <div class="d-flex justify-content-center">\n                        <button class="btn btn-primary answer-btn" data-answer="A">A</button>\n                        <button class="btn btn-primary answer-btn" data-answer="B">B</button>\n                        <button class="btn btn-primary answer-btn" data-answer="C">C</button>\n                        <button class="btn btn-primary answer-btn" data-answer="D">D</button>\n                    </div>\n                    <div class="feedback mt-3"></div>\n                </div>`;
+                $('#question-container').append(html);
+            });
+            questions = $('.question');
+        }
+
+        function fetchMoreIfNeeded() {
+            if (loading) return;
+            if (questions.length - currentIndex <= 3) {
+                loading = true;
+                $.get('/fetch-questions/', {
+                    session_code: sessionCode,
+                    subtopic: subtopic,
+                    exclude: collectIds()
+                }).done(function (data) {
+                    addQuestionsToDOM(data.questions);
+                }).always(function () { loading = false; });
+            }
+        }
+
+        $(document).on('click', '.answer-btn', function () {
             const question = $(this).closest('.question');
             const selectedAnswer = $(this).data('answer');
             const correctAnswer = question.data('answer');
             const feedback = question.find('.feedback');
             const isCorrect = selectedAnswer === correctAnswer;
-
             feedback
                 .text(isCorrect ? 'Correct!' : `Wrong! Correct answer: ${correctAnswer}`)
                 .removeClass('correct wrong')
                 .addClass(isCorrect ? 'correct' : 'wrong')
                 .fadeIn();
-
             setTimeout(() => feedback.fadeOut(), 2000);
         });
 
-        $('.side-button').click(function () {
+        $(document).on('click', '.side-button', function () {
             $(this).toggleClass('active');
         });
 
-        $('.reveal').click(function () {
+        $(document).on('click', '.reveal', function () {
             const correctAnswer = $(this).closest('.question').data('answer');
             $('#revealAnswerModal .modal-body').text(`The correct answer is: ${correctAnswer}`);
             $('#revealAnswerModal').modal('show');
@@ -276,6 +303,7 @@
             questions.eq(currentIndex).hide();
             currentIndex = (currentIndex + 1) % questions.length;
             questions.eq(currentIndex).show();
+            fetchMoreIfNeeded();
         });
     </script>
 </body>

--- a/main/tests.py
+++ b/main/tests.py
@@ -1,3 +1,38 @@
-from django.test import TestCase
+from django.test import TestCase, Client
+import os
+import mongomock
+os.environ.setdefault('MONGO_URI', 'mongodb://localhost:27017')
+from main import db
 
-# Create your tests here.
+
+class FetchQuestionsTest(TestCase):
+    def setUp(self):
+        self.client = Client()
+        mock_client = mongomock.MongoClient()
+        database = mock_client['testdb']
+        db.questions_col = database['questions']
+        db.users_col = database['users']
+        db.user_activity_col = database['user_activity']
+        # Also patch module-level references in views
+        from main import views
+        views.questions_col = db.questions_col
+        views.users_col = db.users_col
+        views.user_activity_col = db.user_activity_col
+        for i in range(15):
+            db.questions_col.insert_one({
+                'question_id': f'Q{i}',
+                'session_code': 'S1',
+                'subtopic': 'T1',
+                'image_base64': '',
+                'answer': 'A',
+            })
+
+    def test_fetch_questions_limit(self):
+        resp = self.client.get('/fetch-questions/', {
+            'session_code': 'S1',
+            'subtopic': 'T1',
+            'limit': 10
+        })
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(len(data['questions']), 10)

--- a/main/urls.py
+++ b/main/urls.py
@@ -5,6 +5,7 @@ urlpatterns = [
     path('',views.home, name='home'),
     path('get-subtopics/', views.get_subtopics, name='get_subtopics'),
     path('practice-questions/', views.practice_questions, name='practice_questions'),
+    path('fetch-questions/', views.fetch_questions, name='fetch_questions'),
     path('check-answer/', views.check_answer, name='check_answer'),
     path('question-bank/', views.question_bank, name='question_bank'),
     path('login/', views.login_view, name='login'),

--- a/main/views.py
+++ b/main/views.py
@@ -6,6 +6,7 @@ from django.views.decorators.csrf import csrf_exempt
 
 from .db import questions_col, users_col, user_activity_col, get_next_user_id
 from types import SimpleNamespace
+import random
 
 def register(request):
     """Handle user registration."""
@@ -92,20 +93,52 @@ def get_subtopics(request):
 
 import random
 
+def get_random_questions(session_code, subtopic, exclude=None, limit=10):
+    """Helper to fetch a random subset of questions."""
+    query = {'session_code': session_code, 'subtopic': subtopic}
+    if exclude:
+        query['question_id'] = {'$nin': exclude}
+    docs = list(questions_col.find(query))
+    random.shuffle(docs)
+    return docs[:limit]
+
+
 def practice_questions(request):
-    """Render the practice questions page with questions in random order."""
+    """Render the practice questions page with an initial batch of questions."""
     session_code = request.GET.get('session_code')
     subtopic = request.GET.get('subtopic')
 
     if not session_code or not subtopic:
         return render(request, 'error.html', {'message': 'Session code and subtopic are required'})
 
-    # Fetch questions from MongoDB matching the filters
-    docs = list(questions_col.find({'session_code': session_code, 'subtopic': subtopic}))
-    random.shuffle(docs)
-    # Convert dicts to simple objects for template compatibility
+    docs = get_random_questions(session_code, subtopic, limit=10)
     questions = [SimpleNamespace(**doc) for doc in docs]
-    return render(request, 'practice_questions.html', {'questions': questions})
+    context = {
+        'questions': questions,
+        'session_code': session_code,
+        'subtopic': subtopic,
+    }
+    return render(request, 'practice_questions.html', context)
+
+
+def fetch_questions(request):
+    """Return additional questions for asynchronous loading."""
+    session_code = request.GET.get('session_code')
+    subtopic = request.GET.get('subtopic')
+    exclude = request.GET.getlist('exclude[]') or request.GET.get('exclude', '')
+    if isinstance(exclude, str):
+        exclude = [e for e in exclude.split(',') if e]
+    limit = int(request.GET.get('limit', 10))
+
+    docs = get_random_questions(session_code, subtopic, exclude, limit)
+    questions = []
+    for doc in docs:
+        questions.append({
+            'question_id': doc.get('question_id'),
+            'image_base64': doc.get('image_base64'),
+            'answer': doc.get('answer'),
+        })
+    return JsonResponse({'questions': questions})
 
 from django.views.decorators.csrf import csrf_exempt
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ asgiref==3.8.1
 Django==5.1.3
 sqlparse==0.5.2
 pymongo==4.6.1
+mongomock==4.1.2


### PR DESCRIPTION
## Summary
- fetch initial questions in `practice_questions` view with helper
- expose `/fetch-questions/` endpoint for additional questions
- load more questions via AJAX on the practice page
- include `mongomock` for tests and add unit test for new endpoint

## Testing
- `pip install -q -r requirements.txt`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_686f8d2c98e88321b0ebbcbf8b583550