### PR TITLE
Add user activity tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ This version uses **MongoDB** for data storage instead of the default SQLite dat
   - Animated hero section.
   - Real-time display of the total number of questions in the database.
 
+## Tracking User Activity
+
+The `user_activity` collection stores per-question data linked by `user_id` and
+`question_id`. It records whether questions are starred or bookmarked, if they
+have been solved correctly and how long the user spent on each. Superusers can
+view these records at `/admin/user-activity/`.
+
 ## Password Security
 
 User passwords are **never stored in plain text**. During registration the

--- a/main/db.py
+++ b/main/db.py
@@ -11,6 +11,27 @@ users_col = db['users']
 user_activity_col = db['user_activity']
 
 
+def get_or_create_activity(user_id: str, question_id: str) -> dict:
+    """Fetch a user/question activity record or create a default one."""
+    doc = user_activity_col.find_one({'user_id': user_id, 'question_id': question_id})
+    if doc:
+        return doc
+
+    doc = {
+        'user_id': user_id,
+        'question_id': question_id,
+        'solved': False,
+        'correct': False,
+        'bookmarked': False,
+        'starred': False,
+        'times_viewed': 0,
+        'time_started': None,
+        'time_took': None,
+    }
+    user_activity_col.insert_one(doc)
+    return doc
+
+
 def get_next_user_id() -> str:
     """Generate a simple incremental user_id like U1, U2, ..."""
     last = users_col.find_one(sort=[('user_id', -1)])

--- a/main/templates/navbar.html
+++ b/main/templates/navbar.html
@@ -12,6 +12,11 @@
                 <li class="nav-item">
                     <a class="nav-link" href="/question-bank/">Question Bank</a>
                 </li>
+                {% if request.user.is_staff %}
+                <li class="nav-item">
+                    <a class="nav-link" href="/admin/user-activity/">Activity</a>
+                </li>
+                {% endif %}
             </ul>
             <ul class="navbar-nav ms-auto">
                 {% if request.session.user_name %}

--- a/main/templates/practice_questions.html
+++ b/main/templates/practice_questions.html
@@ -239,6 +239,7 @@
         let currentIndex = 0;
         const questions = $('.question');
         questions.hide().eq(currentIndex).show();
+        recordStart($(questions[currentIndex]).data('question-id'));
 
         $('.answer-btn').click(function () {
             const question = $(this).closest('.question');
@@ -246,6 +247,12 @@
             const correctAnswer = question.data('answer');
             const feedback = question.find('.feedback');
             const isCorrect = selectedAnswer === correctAnswer;
+
+            $.post('/update-activity/', {
+                question_id: question.data('question-id'),
+                action: 'answer',
+                correct: isCorrect
+            });
 
             feedback
                 .text(isCorrect ? 'Correct!' : `Wrong! Correct answer: ${correctAnswer}`)
@@ -256,8 +263,22 @@
             setTimeout(() => feedback.fadeOut(), 2000);
         });
 
-        $('.side-button').click(function () {
+        $('.side-button.star').click(function () {
             $(this).toggleClass('active');
+            const q = $(this).closest('.question');
+            $.post('/update-activity/', {
+                question_id: q.data('question-id'),
+                action: 'star'
+            });
+        });
+
+        $('.side-button.bookmark').click(function () {
+            $(this).toggleClass('active');
+            const q = $(this).closest('.question');
+            $.post('/update-activity/', {
+                question_id: q.data('question-id'),
+                action: 'bookmark'
+            });
         });
 
         $('.reveal').click(function () {
@@ -270,13 +291,22 @@
             questions.eq(currentIndex).hide();
             currentIndex = (currentIndex - 1 + questions.length) % questions.length;
             questions.eq(currentIndex).show();
+            recordStart($(questions[currentIndex]).data('question-id'));
         });
 
         $('#next-btn').click(function () {
             questions.eq(currentIndex).hide();
             currentIndex = (currentIndex + 1) % questions.length;
             questions.eq(currentIndex).show();
+            recordStart($(questions[currentIndex]).data('question-id'));
         });
+
+        function recordStart(qid) {
+            $.post('/update-activity/', {
+                question_id: qid,
+                action: 'start'
+            });
+        }
     </script>
 </body>
 </html>

--- a/main/templates/user_activity_admin.html
+++ b/main/templates/user_activity_admin.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>User Activity</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+{% include 'navbar.html' %}
+<div class="container mt-4">
+    <h1>User Activity</h1>
+    <table class="table table-striped">
+        <thead>
+            <tr>
+                <th>User ID</th>
+                <th>Question ID</th>
+                <th>Solved</th>
+                <th>Correct</th>
+                <th>Bookmarked</th>
+                <th>Starred</th>
+                <th>Times Viewed</th>
+                <th>Time Spent (seconds)</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for a in records %}
+            <tr>
+                <td>{{ a.user_id }}</td>
+                <td>{{ a.question_id }}</td>
+                <td>{{ a.solved }}</td>
+                <td>{{ a.correct }}</td>
+                <td>{{ a.bookmarked }}</td>
+                <td>{{ a.starred }}</td>
+                <td>{{ a.times_viewed }}</td>
+                <td>{% if a.time_took %}{{ a.time_took.total_seconds }}{% else %}-{% endif %}</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/main/urls.py
+++ b/main/urls.py
@@ -6,9 +6,11 @@ urlpatterns = [
     path('get-subtopics/', views.get_subtopics, name='get_subtopics'),
     path('practice-questions/', views.practice_questions, name='practice_questions'),
     path('check-answer/', views.check_answer, name='check_answer'),
+    path('update-activity/', views.update_activity, name='update_activity'),
     path('question-bank/', views.question_bank, name='question_bank'),
     path('login/', views.login_view, name='login'),
     path('register/', views.register, name='register'),
     path('logout/', views.logout_view, name='logout'),
+    path('admin/user-activity/', views.user_activity_admin, name='user_activity_admin'),
 ]
 


### PR DESCRIPTION
## Summary
- track user activity in new `user_activity` collection
- expose a CSRF-exempt endpoint to update activity
- track question start, answers, bookmarking and starring from the frontend
- add simple admin page at `/admin/user-activity/`
- link to activity page from navbar
- document activity tracking in README

## Testing
- `pip install -r requirements.txt`
- `python manage.py check` *(fails: ConfigurationError: The DNS query name does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6872d229fee08321ad2e847fd474b0ff