### PR TITLE
Enhance admin dashboard

### DIFF
--- a/main/admin.py
+++ b/main/admin.py
@@ -1,0 +1,6 @@
+from django.contrib import admin
+
+# Simple customization of the default Django admin site
+admin.site.site_header = "Quiz Administration"
+admin.site.site_title = "Quiz Admin"
+admin.site.index_title = "Site Overview"

--- a/main/templates/user_activity_admin.html
+++ b/main/templates/user_activity_admin.html
@@ -9,6 +9,64 @@
 {% include 'navbar.html' %}
 <div class="container mt-4">
     <h1>User Activity</h1>
+    <div class="row row-cols-2 row-cols-md-4 g-3 mb-4">
+        <div class="col">
+            <div class="card text-center">
+                <div class="card-body">
+                    <h6 class="card-title">Users</h6>
+                    <p class="card-text fw-bold">{{ summary.total_users }}</p>
+                </div>
+            </div>
+        </div>
+        <div class="col">
+            <div class="card text-center">
+                <div class="card-body">
+                    <h6 class="card-title">Questions</h6>
+                    <p class="card-text fw-bold">{{ summary.total_questions }}</p>
+                </div>
+            </div>
+        </div>
+        <div class="col">
+            <div class="card text-center">
+                <div class="card-body">
+                    <h6 class="card-title">Activity Records</h6>
+                    <p class="card-text fw-bold">{{ summary.total_records }}</p>
+                </div>
+            </div>
+        </div>
+        <div class="col">
+            <div class="card text-center">
+                <div class="card-body">
+                    <h6 class="card-title">Solved</h6>
+                    <p class="card-text fw-bold">{{ summary.solved }}</p>
+                </div>
+            </div>
+        </div>
+        <div class="col">
+            <div class="card text-center">
+                <div class="card-body">
+                    <h6 class="card-title">Correct</h6>
+                    <p class="card-text fw-bold">{{ summary.correct }}</p>
+                </div>
+            </div>
+        </div>
+        <div class="col">
+            <div class="card text-center">
+                <div class="card-body">
+                    <h6 class="card-title">Starred</h6>
+                    <p class="card-text fw-bold">{{ summary.starred }}</p>
+                </div>
+            </div>
+        </div>
+        <div class="col">
+            <div class="card text-center">
+                <div class="card-body">
+                    <h6 class="card-title">Bookmarked</h6>
+                    <p class="card-text fw-bold">{{ summary.bookmarked }}</p>
+                </div>
+            </div>
+        </div>
+    </div>
     <table class="table table-striped">
         <thead>
             <tr>

--- a/main/views.py
+++ b/main/views.py
@@ -180,7 +180,22 @@ def update_activity(request):
 
 @staff_member_required
 def user_activity_admin(request):
-    """Display basic listing of user activity records for admins."""
+    """Display user activity records with summary statistics for admins."""
     records = [SimpleNamespace(**doc) for doc in user_activity_col.find()]
-    return render(request, 'user_activity_admin.html', {'records': records})
+
+    summary = {
+        "total_users": users_col.count_documents({}),
+        "total_questions": questions_col.count_documents({}),
+        "total_records": user_activity_col.count_documents({}),
+        "solved": user_activity_col.count_documents({"solved": True}),
+        "correct": user_activity_col.count_documents({"correct": True}),
+        "starred": user_activity_col.count_documents({"starred": True}),
+        "bookmarked": user_activity_col.count_documents({"bookmarked": True}),
+    }
+
+    context = {
+        "records": records,
+        "summary": summary,
+    }
+    return render(request, "user_activity_admin.html", context)
 


### PR DESCRIPTION
## Summary
- expose custom admin site settings
- add statistics to the user activity admin view
- show summary cards in the admin template

## Testing
- `python manage.py check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6872d64ab8388321872e27ad5f5a078a